### PR TITLE
fix: resolve SyntaxWarning from invalid escape sequences

### DIFF
--- a/chap02/calc/calc_lexer.py
+++ b/chap02/calc/calc_lexer.py
@@ -40,7 +40,7 @@ def tokenize(stream):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap02/example/inputstream.py
+++ b/chap02/example/inputstream.py
@@ -12,7 +12,7 @@ class InputStream:
                                   .replace('\t','') \
                                   .replace('\n','') 
         self.stream = [c for c in clean_stream]
-        self.stream.append('\eof')
+        self.stream.append(r'\eof')
         self.stream_ix = 0
 
     def pointer(self):
@@ -33,7 +33,7 @@ class InputStream:
                               .format(self.stream[self.stream_ix], sym))
 
     def end_of_file(self):
-        if self.pointer() == '\eof':
+        if self.pointer() == r'\eof':
             return True
         else:
             return False

--- a/chap02/exp0/inputstream.py
+++ b/chap02/exp0/inputstream.py
@@ -12,7 +12,7 @@ class InputStream:
                                   .replace('\t','') \
                                   .replace('\n','') 
         self.stream = [c for c in clean_stream]
-        self.stream.append('\eof')
+        self.stream.append(r'\eof')
         self.stream_ix = 0
 
     def pointer(self):
@@ -33,7 +33,7 @@ class InputStream:
                               .format(self.stream[self.stream_ix], sym))
 
     def end_of_file(self):
-        if self.pointer() == '\eof':
+        if self.pointer() == r'\eof':
             return True
         else:
             return False

--- a/chap02/exp0count/inputstream.py
+++ b/chap02/exp0count/inputstream.py
@@ -12,7 +12,7 @@ class InputStream:
                                   .replace('\t','') \
                                   .replace('\n','') 
         self.stream = [c for c in clean_stream]
-        self.stream.append('\eof')
+        self.stream.append(r'\eof')
         self.stream_ix = 0
 
     def pointer(self):
@@ -33,7 +33,7 @@ class InputStream:
                               .format(self.stream[self.stream_ix], sym))
 
     def end_of_file(self):
-        if self.pointer() == '\eof':
+        if self.pointer() == r'\eof':
             return True
         else:
             return False

--- a/chap03/exp1/exp1_lexer.py
+++ b/chap03/exp1/exp1_lexer.py
@@ -45,7 +45,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap03/exp1_interp/exp1_lexer.py
+++ b/chap03/exp1_interp/exp1_lexer.py
@@ -45,7 +45,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap03/exp1_pp/exp1_lexer.py
+++ b/chap03/exp1_pp/exp1_lexer.py
@@ -45,7 +45,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap04/exp1bytecode/exp1bytecode_lexer.py
+++ b/chap04/exp1bytecode/exp1bytecode_lexer.py
@@ -57,7 +57,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap04/exp1bytecode_interp/exp1bytecode_lexer.py
+++ b/chap04/exp1bytecode_interp/exp1bytecode_lexer.py
@@ -57,7 +57,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap05/cuppa1/cuppa1_lexer.py
+++ b/chap05/cuppa1/cuppa1_lexer.py
@@ -56,7 +56,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap05/cuppa1_interp/cuppa1_lexer.py
+++ b/chap05/cuppa1_interp/cuppa1_lexer.py
@@ -56,7 +56,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap05/cuppa1_pp/cuppa1_lexer.py
+++ b/chap05/cuppa1_pp/cuppa1_lexer.py
@@ -56,7 +56,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap06/cuppa1_compiler/cuppa1_lexer.py
+++ b/chap06/cuppa1_compiler/cuppa1_lexer.py
@@ -56,7 +56,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap07/cuppa2/cuppa2_lexer.py
+++ b/chap07/cuppa2/cuppa2_lexer.py
@@ -57,7 +57,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap07/cuppa2_compiler/cuppa2_lexer.py
+++ b/chap07/cuppa2_compiler/cuppa2_lexer.py
@@ -57,7 +57,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap07/cuppa2_interp/cuppa2_lexer.py
+++ b/chap07/cuppa2_interp/cuppa2_lexer.py
@@ -57,7 +57,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap08/cuppa3/cuppa3_lexer.py
+++ b/chap08/cuppa3/cuppa3_lexer.py
@@ -59,7 +59,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap08/cuppa3_interp/cuppa3_lexer.py
+++ b/chap08/cuppa3_interp/cuppa3_lexer.py
@@ -59,7 +59,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap09/cuppa3_compiler/cuppa3_lexer.py
+++ b/chap09/cuppa3_compiler/cuppa3_lexer.py
@@ -59,7 +59,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap09/exp2bytecode/exp2bytecode_lexer.py
+++ b/chap09/exp2bytecode/exp2bytecode_lexer.py
@@ -69,7 +69,7 @@ def tokenize(code):
         if type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap09/exp2bytecode_interp/exp2bytecode_lexer.py
+++ b/chap09/exp2bytecode_interp/exp2bytecode_lexer.py
@@ -69,7 +69,7 @@ def tokenize(code):
         if type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap10/cuppa3_compiler_x86_64/cuppa3_lexer.py
+++ b/chap10/cuppa3_compiler_x86_64/cuppa3_lexer.py
@@ -59,7 +59,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap11/cuppa4/cuppa4_lexer.py
+++ b/chap11/cuppa4/cuppa4_lexer.py
@@ -66,7 +66,7 @@ def tokenize(code):
         elif type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap11/cuppa4_interp/cuppa4_lexer.py
+++ b/chap11/cuppa4_interp/cuppa4_lexer.py
@@ -66,7 +66,7 @@ def tokenize(code):
         elif type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap12/cuppa5/cuppa5_lexer.py
+++ b/chap12/cuppa5/cuppa5_lexer.py
@@ -69,7 +69,7 @@ def tokenize(code):
         elif type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap12/cuppa5_interp/cuppa5_lexer.py
+++ b/chap12/cuppa5_interp/cuppa5_lexer.py
@@ -69,7 +69,7 @@ def tokenize(code):
         elif type == 'UNKNOWN':
             raise ValueError("unexpected character '{}'".format(value))
         tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:

--- a/chap14/cuppa1_llvm_cc/cuppa1_lexer.py
+++ b/chap14/cuppa1_llvm_cc/cuppa1_lexer.py
@@ -56,7 +56,7 @@ def tokenize(code):
             raise ValueError("unexpected character '{}'".format(value))
         else:
             tokens.append(Token(type, value))
-    tokens.append(Token('EOF', '\eof'))
+    tokens.append(Token('EOF', r'\eof'))
     return tokens
 
 class Lexer:


### PR DESCRIPTION
With [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes), the following change was made:

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/dev/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, [SyntaxError](https://docs.python.org/dev/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/dev/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)

This causes warnings, which will become errors in future versions, such as

> chap02/calc/calc_lexer.py:43: SyntaxWarning: invalid escape sequence '\e'
  tokens.append(Token('EOF', '\eof'))

Replacing `'\eof'` with `r'\eof'` is sufficient to resolve this.

I diff'ed the output of python3.11 running the upstream code vs python 3.12 running the modified code using [these commands](https://github.com/user-attachments/files/17092117/diff.txt):

> diff <(python3.11 upstream/chap02/calc/calc_lexer.py) <(python3.12 plipy-code/chap02/calc/calc_lexer.py) 

There were no differences between the two.
